### PR TITLE
Feature/Extra Config Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ The following configuration options are supported:
 - **filenameJsonata**: When outputting as an attachment, specify a JSONata expression that creates a dynamic filename for the attachment. The JSONata executes relative to `msg`. If this is not specified, the component will output the file as `jsonToXml.xml`.
 - **headerStandalone**: Specify whether to set the `standalone` attribute to `true` in the XML header for the output.
 - **uploadToAttachment**: When true, the output XML will be placed directly into the attachment service. The attachment information will be provided in both the message's attachments section as well as `attachmentUrl` and `attachmentSize` will be populated. The attachment size will be described in bytes. When this value is false or not specified, the resulting XML will be provided in the `xmlString` field on the message.
+- **cData**: A boolean indicating whether or not there is CDATA contained in the JSON object that should be ignored by the parser. False by default
+- **docType**: Specify the system doc type by providing a link to a dtd file. `null` by default.
+- **renderOpts**: An object containing 3 properties, `pretty`, `newline`, and `indent`. 
+  - **pretty**: A boolean that is true by default. Pretty prints the XML output with indentation and new lines. 
+  - **newline**: A string value to use for the new line character. Can only be used in conjunction with `pretty: true`. Defaults to `\n`. 
+  - **indent**: A string value to use for the indentation/white space characters. Can only be used in conjunction with `pretty:true`. Defaults to `  `. 
 
 ## Attachment Storage Service Interaction
 

--- a/lib/actions/jsonToXml.js
+++ b/lib/actions/jsonToXml.js
@@ -12,7 +12,9 @@ module.exports.process = async function process(msg, cfg, snapshot = {}, headers
   const wrapped = wrapper(this, msg, cfg, {});
   const TOKEN = cfg.token ? cfg.token : tokenData.apiKey;
   const { input } = msg.data;
-  const { uploadToAttachment, excludeXmlHeader, headerStandalone } = cfg;
+  const {
+    uploadToAttachment, excludeXmlHeader, headerStandalone, renderOpts, cData, docType,
+  } = cfg;
 
   this.logger.info('Message received.');
 
@@ -28,7 +30,14 @@ module.exports.process = async function process(msg, cfg, snapshot = {}, headers
       encoding: 'UTF-8',
     },
     headless: excludeXmlHeader,
+    doctype: docType ? { pubID: docType } : null,
+    cdata: cData,
   };
+
+  if (renderOpts) {
+    options.renderOpts = renderOpts;
+  }
+
   const builder = new xml2js.Builder(options);
 
   // Check to make sure that input has at most one key

--- a/spec/json2xml.spec.js
+++ b/spec/json2xml.spec.js
@@ -219,4 +219,141 @@ describe('JSON to XML', () => {
       xmlString: '<someTag id="my id">my inner text</someTag>',
     });
   });
+
+  describe('Render Options Config', () => {
+    afterEach(() => {
+      context.emit.resetHistory();
+    });
+
+    it('Pretty false', async () => {
+      const msg = {
+        data: {
+          input: inputMessage,
+        },
+      };
+
+      const cfg = {
+        renderOpts: {
+          pretty: false,
+        },
+      };
+
+      const expectedOutput = '<?xml version="1.0" encoding="UTF-8"?><data><input><ORDERRESPONSE xmlns:ns2="http://www.bmecat.org/bmecat/2005" version="2.1"><ORDERRESPONSE_HEADER><ORDERRESPONSE_INFO><ORDERRESPONSE_DATE>2020-04-07T09:07:45.188Z</ORDERRESPONSE_DATE><ORDER_ID>1234</ORDER_ID></ORDERRESPONSE_INFO></ORDERRESPONSE_HEADER><ORDERRESPONSE_ITEM_LIST/></ORDERRESPONSE></input></data>';
+
+      await json2xml.process.call(context, msg, cfg, {});
+      expect(context.emit.getCalls().length).to.be.eql(1);
+      expect(context.emit.getCall(0).args[1].data.xmlString).to.deep.eql(expectedOutput);
+    });
+
+    it('Not provided', async () => {
+      const msg = {
+        data: {
+          input: inputMessage,
+        },
+      };
+
+      const cfg = {};
+
+      const expectedOutput = '<?xml version="1.0" encoding="UTF-8"?>\n<data>\n  <input>\n    <ORDERRESPONSE xmlns:ns2="http://www.bmecat.org/bmecat/2005" version="2.1">\n      <ORDERRESPONSE_HEADER>\n        <ORDERRESPONSE_INFO>\n          <ORDERRESPONSE_DATE>2020-04-07T09:07:45.188Z</ORDERRESPONSE_DATE>\n          <ORDER_ID>1234</ORDER_ID>\n        </ORDERRESPONSE_INFO>\n      </ORDERRESPONSE_HEADER>\n      <ORDERRESPONSE_ITEM_LIST/>\n    </ORDERRESPONSE>\n  </input>\n</data>';
+
+      await json2xml.process.call(context, msg, cfg, {});
+      expect(context.emit.getCalls().length).to.be.eql(1);
+      expect(context.emit.getCall(0).args[1].data.xmlString).to.deep.eql(expectedOutput);
+    });
+
+    it('Pretty true, different new line char and additional indent spaces', async () => {
+      const msg = {
+        data: {
+          input: inputMessage,
+        },
+      };
+
+      const cfg = {
+        renderOpts: {
+          pretty: true,
+          newline: 'NEWLINE',
+          indent: 'INDENT',
+        },
+      };
+
+      const expectedOutput = '<?xml version="1.0" encoding="UTF-8"?>NEWLINE<data>NEWLINEINDENT<input>NEWLINEINDENTINDENT<ORDERRESPONSE xmlns:ns2="http://www.bmecat.org/bmecat/2005" version="2.1">NEWLINEINDENTINDENTINDENT<ORDERRESPONSE_HEADER>NEWLINEINDENTINDENTINDENTINDENT<ORDERRESPONSE_INFO>NEWLINEINDENTINDENTINDENTINDENTINDENT<ORDERRESPONSE_DATE>2020-04-07T09:07:45.188Z</ORDERRESPONSE_DATE>NEWLINEINDENTINDENTINDENTINDENTINDENT<ORDER_ID>1234</ORDER_ID>NEWLINEINDENTINDENTINDENTINDENT</ORDERRESPONSE_INFO>NEWLINEINDENTINDENTINDENT</ORDERRESPONSE_HEADER>NEWLINEINDENTINDENTINDENT<ORDERRESPONSE_ITEM_LIST/>NEWLINEINDENTINDENT</ORDERRESPONSE>NEWLINEINDENT</input>NEWLINE</data>';
+
+      await json2xml.process.call(context, msg, cfg, {});
+      expect(context.emit.getCalls().length).to.be.eql(1);
+      expect(context.emit.getCall(0).args[1].data.xmlString).to.deep.eql(expectedOutput);
+    });
+  });
+
+  describe('CData Config Options', () => {
+    afterEach(() => {
+      context.emit.resetHistory();
+    });
+
+    it('True', async () => {
+      const msg = {
+        data: {
+          input: {
+            nested: {
+              xml: '<?xml version="1.0" encoding="UTF-8"?><parent><child>value</child></parent>',
+            },
+          },
+        },
+      };
+
+      const cfg = {
+        cData: true,
+      };
+
+      const expectedOutput = '<?xml version="1.0" encoding="UTF-8"?>\n<nested>\n  <xml><![CDATA[<?xml version="1.0" encoding="UTF-8"?><parent><child>value</child></parent>]]></xml>\n</nested>';
+
+      await json2xml.process.call(context, msg, cfg, {});
+      expect(context.emit.getCalls().length).to.be.eql(1);
+      expect(context.emit.getCall(0).args[1].data.xmlString).to.deep.eql(expectedOutput);
+    });
+
+    it('False', async () => {
+      const msg = {
+        data: {
+          input: {
+            nested: {
+              xml: '<?xml version="1.0" encoding="UTF-8"?><parent><child>value</child></parent>',
+            },
+          },
+        },
+      };
+
+      const cfg = {
+        cData: false,
+      };
+
+      const expectedOutput = '<?xml version="1.0" encoding="UTF-8"?>\n<nested>\n  <xml>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&lt;parent&gt;&lt;child&gt;value&lt;/child&gt;&lt;/parent&gt;</xml>\n</nested>';
+
+      await json2xml.process.call(context, msg, cfg, {});
+      expect(context.emit.getCalls().length).to.be.eql(1);
+      expect(context.emit.getCall(0).args[1].data.xmlString).to.deep.eql(expectedOutput);
+    });
+  });
+
+  describe('DocType Config Options', async () => {
+    afterEach(() => {
+      context.emit.resetHistory();
+    });
+
+    it('CXML', async () => {
+      const msg = {
+        data: {
+          input: inputMessage,
+        },
+      };
+
+      const cfg = {
+        docType: 'http://xml.cxml.org/schemas/cXML/1.2.014/cXML.dtd',
+        excludeXmlHeader: false,
+      };
+
+      await json2xml.process.call(context, msg, cfg, {});
+      expect(context.emit.getCalls().length).to.be.eql(1);
+      expect(context.emit.getCall(0).args[1].data.xmlString).to.contain('<!DOCTYPE data SYSTEM "http://xml.cxml.org/schemas/cXML/1.2.014/cXML.dtd">');
+    });
+  });
 });


### PR DESCRIPTION
This PR adds the following additional configs:
- `renderOpts` to adjust how the XML is formatted upon return
- `cData` to turn on/off the ability to use CDATA in the JSON/XML
- `docType` to provide a custom `.dtd` file